### PR TITLE
Separating network and server creations

### DIFF
--- a/network/main.tf
+++ b/network/main.tf
@@ -1,0 +1,44 @@
+provider "azurerm" {}
+
+resource "azurerm_resource_group" "main" {
+  name     = "${var.prefix}"
+  location = "${var.region}"
+}
+
+resource "azurerm_virtual_network" "main" {
+  name                = "${var.prefix}-network"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.main.location}"
+  resource_group_name = "${azurerm_resource_group.main.name}"
+}
+
+
+resource "azurerm_subnet" "internal" {
+  name                 = "internal"
+  resource_group_name  = "${azurerm_resource_group.main.name}"
+  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  address_prefix       = "10.0.2.0/24"
+}
+
+
+resource "azurerm_network_security_group" "main" {
+    name                = "${var.prefix}-rdp-nsg"
+    location            = "${var.region}"
+    resource_group_name = "${azurerm_resource_group.main.name}"
+    
+    security_rule {
+        name                       = "RDP"
+        priority                   = 1001
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "3389"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+    }
+
+    tags = {
+        environment = "Staging"
+    }
+}

--- a/network/var.tf
+++ b/network/var.tf
@@ -1,0 +1,10 @@
+variable "prefix" {
+  default = "vm-test-ked"
+}
+
+variable "region" {
+  default = "southeastasia"
+}
+
+variable "vm_admin_username" {}
+variable "vm_admin_password" {}

--- a/servers/main.tf
+++ b/servers/main.tf
@@ -1,0 +1,98 @@
+provider "azurerm" {}
+
+data "azurerm_resource_group" "selected" {
+  name = "${var.prefix}"
+}
+
+data "azurerm_virtual_network" "selected" {
+  name = "${var.prefix}-network"
+  resource_group_name = "${var.prefix}"
+}
+data "azurerm_network_security_group" "selected" {
+  name = "${var.prefix}-rdp-nsg"
+  resource_group_name = "${var.prefix}"
+}
+
+data "azurerm_subnet" "selected" {
+  virtual_network_name="${data.azurerm_virtual_network.selected.name}"
+  resource_group_name = "${data.azurerm_resource_group.selected.name}"
+  name = "internal"  
+}
+
+
+resource "azurerm_public_ip" "main" {
+    name                         = "${var.prefix}-ip"
+    location                     = "${data.azurerm_resource_group.selected.location}"
+    resource_group_name          = "${data.azurerm_resource_group.selected.name}"
+    allocation_method            = "Dynamic"
+
+    tags = {
+        environment = "Staging"
+    }
+}
+
+
+
+resource "azurerm_network_interface" "main" {
+  name                = "${var.prefix}-nic"
+  location            = "${data.azurerm_resource_group.selected.location}"
+  resource_group_name = "${data.azurerm_resource_group.selected.name}"
+
+  network_security_group_id = "${data.azurerm_network_security_group.selected.id}"
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = "${data.azurerm_subnet.selected.id}"
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id = "${azurerm_public_ip.main.id}"
+  }
+}
+
+resource "azurerm_virtual_machine" "main" {
+  name                  = "${var.prefix}-vm"
+  location            = "${data.azurerm_resource_group.selected.location}"
+  resource_group_name = "${data.azurerm_resource_group.selected.name}"
+  network_interface_ids = ["${azurerm_network_interface.main.id}"]
+  vm_size               = "Standard_DS1_v2"
+
+  # Uncomment this line to delete the OS disk automatically when deleting the VM
+  delete_os_disk_on_termination = true
+
+
+  # Uncomment this line to delete the data disks automatically when deleting the VM
+  delete_data_disks_on_termination = true
+
+  storage_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2008-R2-SP1"
+    version   = "latest"
+  }
+
+
+  storage_os_disk {
+    name              = "myosdisk1"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "Standard_LRS"
+  }
+  os_profile {
+    computer_name  = "myvm01"
+    admin_username = "${var.vm_admin_username}"
+    admin_password = "${var.vm_admin_password}"
+  }
+
+
+
+  os_profile_windows_config {
+    provision_vm_agent        = true
+    enable_automatic_upgrades = true
+  }
+
+  tags = {
+    environment = "staging"
+  }
+}
+
+output "rdp-ip" {
+    value = "${azurerm_public_ip.main.ip_address}"
+}

--- a/servers/var.tf
+++ b/servers/var.tf
@@ -1,0 +1,10 @@
+variable "prefix" {
+  default = "vm-test-ked"
+}
+
+variable "region" {
+  default = "southeastasia"
+}
+
+variable "vm_admin_username" {}
+variable "vm_admin_password" {}


### PR DESCRIPTION
Hi there Ked,

Here's is an example of a pull request from me to your repository. In this example, I've made some changes by separating the network creation vs. the server creation. 

I did this to show that it's important to separate things you create/destroy into their own groups. For e.g. you might create/update new servers but not necessarily update the network. So each set of terraforms can be separate.

